### PR TITLE
Reverse-engineered JIS layout macro for 2015 Pegasus Hoof

### DIFF
--- a/keyboards/bpiphany/pegasushoof/2013/2013.h
+++ b/keyboards/bpiphany/pegasushoof/2013/2013.h
@@ -55,21 +55,21 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     )
 
 #define LAYOUT_tkl_jis( \
-  KG6,      KH4, KI4, KI2, KI6, KP5, KL6, KM2, KM4, KO4, KO5, KO6, KO0,        KN5, KN7, KP7, \
-  KG4, KG5, KH5, KI5, KJ5, KJ4, KK4, KK5, KL5, KM5, KF5, KF4, KL4, KO7, KO2,   KR4, KC4, KE4, \
-  KG2, KG7, KH7, KI7, KJ7, KJ2, KK2, KK7, KL7, KM7, KF7, KF2, KL2,             KQ4, KC5, KE5, \
-  KH2, KG3, KH3, KI3, KJ3, KJ6, KK6, KK3, KL3, KM3, KF3, KF6, KO3, KO1,                       \
-  KB2, KG1, KH1, KI1, KJ1, KJ0, KK0, KK1, KL1, KM1, KF0, KL0,      KB3,             KC6,      \
-  KP4, KD2, KN6, KG0,           KQ6,           KH0, KI0, KN0, KM0, KP1,        KC0, KQ0, KR0  \
-  ) { /*        00-A  01-B  02-C  03-D  04-E  05-F  06-G  07-H  08-I  09-J  10-K  11-L  12-M  13-N  14-O  15-P  16-Q  17-R */ \
-     /* 0 */  { KC_NO,  KC_NO,  KC0,    KC_NO,  KC_NO,  KF0,    KG0,    KH0,    KI0,    KJ0,    KK0,    KL0,    KM0,    KN0,    KO0,    KC_NO,  KQ0,    KR0   }, \
-     /* 1 */  { KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,  KG1,    KH1,    KI1,    KJ1,    KK1,    KL1,    KM1,    KC_NO,  KO1,    KP1,    KC_NO,  KC_NO }, \
-     /* 2 */  { KC_NO,  KB2,    KC_NO,  KD2,    KC_NO,  KF2,    KG2,    KH2,    KI2,    KJ2,    KK2,    KL2,    KM2,    KC_NO,  KO2,    KC_NO,  KC_NO,  KC_NO }, \
-     /* 3 */  { KC_NO,  KB3,    KC_NO,  KC_NO,  KC_NO,  KF3,    KG3,    KH3,    KI3,    KJ3,    KK3,    KL3,    KM3,    KC_NO,  KO3,    KC_NO,  KC_NO,  KC_NO }, \
-     /* 4 */  { KC_NO,  KC_NO,  KC4,    KC_NO,  KE4,    KF4,    KG4,    KH4,    KI4,    KJ4,    KK4,    KL4,    KM4,    KC_NO,  KO4,    KP4,    KQ4,    KR4   }, \
-     /* 5 */  { KC_NO,  KC_NO,  KC5,    KC_NO,  KE5,    KF5,    KG5,    KH5,    KI5,    KJ5,    KK5,    KL5,    KM5,    KN5,    KO5,    KP5,    KC_NO,  KC_NO }, \
-     /* 6 */  { KC_NO,  KC_NO,  KC6,    KC_NO,  KC_NO,  KF6,    KG6,    KC_NO,  KI6,    KJ6,    KK6,    KL6,    KC_NO,  KN6,    KO6,    KC_NO,  KQ6,    KC_NO }, \
-     /* 7 */  { KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,  KF7,    KG7,    KH7,    KI7,    KJ7,    KK7,    KL7,    KK7,    KL7,    KO7,    KP7,    KC_NO,  KC_NO }  \
+    KG6,      KH4, KI4, KI2, KI6, KP5, KL6, KM2, KM4, KO4, KO5, KO6, KO0,        KN5, KN7, KP7, \
+    KG4, KG5, KH5, KI5, KJ5, KJ4, KK4, KK5, KL5, KM5, KF5, KF4, KL4, KO7, KO2,   KR4, KC4, KE4, \
+    KG2, KG7, KH7, KI7, KJ7, KJ2, KK2, KK7, KL7, KM7, KF7, KF2, KL2,             KQ4, KC5, KE5, \
+    KH2, KG3, KH3, KI3, KJ3, KJ6, KK6, KK3, KL3, KM3, KF3, KF6, KO3, KO1,                       \
+    KB2,      KG1, KH1, KI1, KJ1, KJ0, KK0, KK1, KL1, KM1, KF0, KL0, KB3,             KC6,      \
+    KP4, KD2, KN6, KG0,           KQ6,           KH0, KI0, KN0, KM0, KP1,        KC0, KQ0, KR0  \
+    ) { /*         00-A  01-B  02-C  03-D  04-E  05-F  06-G  07-H  08-I  09-J  10-K  11-L  12-M  13-N  14-O  15-P  16-Q  17-R */ \
+        /* 0 */  { KC_NO,  KC_NO,  KC0,    KC_NO,  KC_NO,  KF0,    KG0,    KH0,    KI0,    KJ0,    KK0,    KL0,    KM0,    KN0,    KO0,    KC_NO,  KQ0,    KR0   }, \
+        /* 1 */  { KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,  KG1,    KH1,    KI1,    KJ1,    KK1,    KL1,    KM1,    KC_NO,  KO1,    KP1,    KC_NO,  KC_NO }, \
+        /* 2 */  { KC_NO,  KB2,    KC_NO,  KD2,    KC_NO,  KF2,    KG2,    KH2,    KI2,    KJ2,    KK2,    KL2,    KM2,    KC_NO,  KO2,    KC_NO,  KC_NO,  KC_NO }, \
+        /* 3 */  { KC_NO,  KB3,    KC_NO,  KC_NO,  KC_NO,  KF3,    KG3,    KH3,    KI3,    KJ3,    KK3,    KL3,    KM3,    KC_NO,  KO3,    KC_NO,  KC_NO,  KC_NO }, \
+        /* 4 */  { KC_NO,  KC_NO,  KC4,    KC_NO,  KE4,    KF4,    KG4,    KH4,    KI4,    KJ4,    KK4,    KL4,    KM4,    KC_NO,  KO4,    KP4,    KQ4,    KR4   }, \
+        /* 5 */  { KC_NO,  KC_NO,  KC5,    KC_NO,  KE5,    KF5,    KG5,    KH5,    KI5,    KJ5,    KK5,    KL5,    KM5,    KN5,    KO5,    KP5,    KC_NO,  KC_NO }, \
+        /* 6 */  { KC_NO,  KC_NO,  KC6,    KC_NO,  KC_NO,  KF6,    KG6,    KC_NO,  KI6,    KJ6,    KK6,    KL6,    KC_NO,  KN6,    KO6,    KC_NO,  KQ6,    KC_NO }, \
+        /* 7 */  { KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,  KF7,    KG7,    KH7,    KI7,    KJ7,    KK7,    KL7,    KK7,    KL7,    KO7,    KP7,    KC_NO,  KC_NO }  \
 }
 
 inline void ph_caps_led_on(void)  { DDRC |=  (1<<6); PORTC &= ~(1<<6); }

--- a/keyboards/bpiphany/pegasushoof/2015/2015.h
+++ b/keyboards/bpiphany/pegasushoof/2015/2015.h
@@ -24,54 +24,54 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define LAYOUT( \
     KJ6,      KI4, KH4, KH2, KH6, KA7, KE6, KD2, KD4, KB4, KB7, KB6, KB0,   KC7, KC5, KA5, \
-	KJ4, KJ7, KI7, KH7, KG7, KG4, KF4, KF7, KE7, KD7, KR7, KR4, KE4, KB2,   KL4, KO4, KQ4, \
-	KJ2, KJ5, KI5, KH5, KG5, KG2, KF2, KF5, KE5, KD5, KR5, KR2, KE2, KB3,   KK4, KO7, KQ7, \
-	KI2, KJ3, KI3, KH3, KG3, KG6, KF6, KF3, KE3, KD3, KR3, KR6,      KB1,                  \
-	KN2, KI6, KJ1, KI1, KH1, KG1, KG0, KF0, KF1, KE1, KD1, KR0,      KN3,        KO6,      \
-	KA4, KP2, KC6,                KK6,                KC0, KM3, KD0, KA1,   KO0, KK0, KL0  \
-	) { /*        00-A  01-B  02-C  03-D  04-E  05-F  06-G  07-H  08-I  09-J  10-K  11-L  12-M  13-N  14-O  15-P  16-Q  17-R */ \
-		/* 0 */  { ___ , KB0 , KC0 , KD0 , ___ , KF0 , KG0 , ___ , ___ , ___ , KK0 , KL0 , ___ , ___ , KO0 , ___ , ___ , KR0 }, \
-		/* 1 */  { KA1 , KB1 , ___ , KD1 , KE1 , KF1 , KG1 , KH1 , KI1 , KJ1 , ___ , ___ , ___ , ___ , ___ , ___ , ___ , ___ }, \
-		/* 2 */  { ___ , KB2 , ___ , KD2 , KE2 , KF2 , KG2 , KH2 , KI2 , KJ2 , ___ , ___ , ___ , KN2 , ___ , KP2 , ___ , KR2 }, \
-		/* 3 */  { ___ , KB3 , ___ , KD3 , KE3 , KF3 , KG3 , KH3 , KI3 , KJ3 , ___ , ___ , KM3 , KN3 , ___ , ___ , ___ , KR3 }, \
-		/* 4 */  { KA4 , KB4 , ___ , KD4 , KE4 , KF4 , KG4 , KH4 , KI4 , KJ4 , KK4 , KL4 , ___ , ___ , KO4 , ___ , KQ4 , KR4 }, \
-		/* 5 */  { KA5 , ___ , KC5 , KD5 , KE5 , KF5 , KG5 , KH5 , KI5 , KJ5 , ___ , ___ , ___ , ___ , ___ , ___ , ___ , KR5 }, \
-		/* 6 */  { ___ , KB6 , KC6 , ___ , KE6 , KF6 , KG6 , KH6 , KI6 , KJ6 , KK6 , ___ , ___ , ___ , KO6 , ___ , ___ , KR6 }, \
-		/* 7 */  { KA7 , KB7 , KC7 , KD7 , KE7 , KF7 , KG7 , KH7 , KI7 , KJ7 , ___ , ___ , ___ , ___ , KO7 , ___ , KQ7 , KR7 }  \
-	}
+    KJ4, KJ7, KI7, KH7, KG7, KG4, KF4, KF7, KE7, KD7, KR7, KR4, KE4, KB2,   KL4, KO4, KQ4, \
+    KJ2, KJ5, KI5, KH5, KG5, KG2, KF2, KF5, KE5, KD5, KR5, KR2, KE2, KB3,   KK4, KO7, KQ7, \
+    KI2, KJ3, KI3, KH3, KG3, KG6, KF6, KF3, KE3, KD3, KR3, KR6,      KB1,                  \
+    KN2, KI6, KJ1, KI1, KH1, KG1, KG0, KF0, KF1, KE1, KD1, KR0,      KN3,        KO6,      \
+    KA4, KP2, KC6,                KK6,                KC0, KM3, KD0, KA1,   KO0, KK0, KL0  \
+    ) { /*         00-A  01-B  02-C  03-D  04-E  05-F  06-G  07-H  08-I  09-J  10-K  11-L  12-M  13-N  14-O  15-P  16-Q  17-R */ \
+        /* 0 */  { ___ , KB0 , KC0 , KD0 , ___ , KF0 , KG0 , ___ , ___ , ___ , KK0 , KL0 , ___ , ___ , KO0 , ___ , ___ , KR0 }, \
+        /* 1 */  { KA1 , KB1 , ___ , KD1 , KE1 , KF1 , KG1 , KH1 , KI1 , KJ1 , ___ , ___ , ___ , ___ , ___ , ___ , ___ , ___ }, \
+        /* 2 */  { ___ , KB2 , ___ , KD2 , KE2 , KF2 , KG2 , KH2 , KI2 , KJ2 , ___ , ___ , ___ , KN2 , ___ , KP2 , ___ , KR2 }, \
+        /* 3 */  { ___ , KB3 , ___ , KD3 , KE3 , KF3 , KG3 , KH3 , KI3 , KJ3 , ___ , ___ , KM3 , KN3 , ___ , ___ , ___ , KR3 }, \
+        /* 4 */  { KA4 , KB4 , ___ , KD4 , KE4 , KF4 , KG4 , KH4 , KI4 , KJ4 , KK4 , KL4 , ___ , ___ , KO4 , ___ , KQ4 , KR4 }, \
+        /* 5 */  { KA5 , ___ , KC5 , KD5 , KE5 , KF5 , KG5 , KH5 , KI5 , KJ5 , ___ , ___ , ___ , ___ , ___ , ___ , ___ , KR5 }, \
+        /* 6 */  { ___ , KB6 , KC6 , ___ , KE6 , KF6 , KG6 , KH6 , KI6 , KJ6 , KK6 , ___ , ___ , ___ , KO6 , ___ , ___ , KR6 }, \
+        /* 7 */  { KA7 , KB7 , KC7 , KD7 , KE7 , KF7 , KG7 , KH7 , KI7 , KJ7 , ___ , ___ , ___ , ___ , KO7 , ___ , KQ7 , KR7 }  \
+    }
 
 #define LAYOUT_tkl_ansi( \
     KJ6,      KI4, KH4, KH2, KH6, KA7, KE6, KD2, KD4, KB4, KB7, KB6, KB0,   KC7, KC5, KA5, \
-	KJ4, KJ7, KI7, KH7, KG7, KG4, KF4, KF7, KE7, KD7, KR7, KR4, KE4, KB2,   KL4, KO4, KQ4, \
-	KJ2, KJ5, KI5, KH5, KG5, KG2, KF2, KF5, KE5, KD5, KR5, KR2, KE2, KB3,   KK4, KO7, KQ7, \
-	KI2, KJ3, KI3, KH3, KG3, KG6, KF6, KF3, KE3, KD3, KR3, KR6,      KB1,                  \
-	KN2,      KJ1, KI1, KH1, KG1, KG0, KF0, KF1, KE1, KD1, KR0,      KN3,        KO6,      \
-	KA4, KP2, KC6,                KK6,                KC0, KM3, KD0, KA1,   KO0, KK0, KL0  \
-	) LAYOUT ( \
-        KJ6,        KI4, KH4, KH2, KH6, KA7, KE6, KD2, KD4, KB4, KB7, KB6, KB0,   KC7, KC5, KA5, \
-	    KJ4, KJ7,   KI7, KH7, KG7, KG4, KF4, KF7, KE7, KD7, KR7, KR4, KE4, KB2,   KL4, KO4, KQ4, \
-	    KJ2, KJ5,   KI5, KH5, KG5, KG2, KF2, KF5, KE5, KD5, KR5, KR2, KE2, KB3,   KK4, KO7, KQ7, \
-    	KI2, KJ3,   KI3, KH3, KG3, KG6, KF6, KF3, KE3, KD3, KR3, KR6,      KB1,                  \
-	    KN2, KC_NO, KJ1, KI1, KH1, KG1, KG0, KF0, KF1, KE1, KD1, KR0,      KN3,        KO6,      \
-	    KA4, KP2,   KC6,                KK6,                KC0, KM3, KD0, KA1,   KO0, KK0, KL0  \
-     )
+    KJ4, KJ7, KI7, KH7, KG7, KG4, KF4, KF7, KE7, KD7, KR7, KR4, KE4, KB2,   KL4, KO4, KQ4, \
+    KJ2, KJ5, KI5, KH5, KG5, KG2, KF2, KF5, KE5, KD5, KR5, KR2, KE2, KB3,   KK4, KO7, KQ7, \
+    KI2, KJ3, KI3, KH3, KG3, KG6, KF6, KF3, KE3, KD3, KR3, KR6,      KB1,                  \
+    KN2,      KJ1, KI1, KH1, KG1, KG0, KF0, KF1, KE1, KD1, KR0,      KN3,        KO6,      \
+    KA4, KP2, KC6,                KK6,                KC0, KM3, KD0, KA1,   KO0, KK0, KL0  \
+    ) LAYOUT( \
+        KJ6,      KI4, KH4, KH2, KH6, KA7, KE6, KD2, KD4, KB4, KB7, KB6, KB0,   KC7, KC5, KA5, \
+        KJ4, KJ7, KI7, KH7, KG7, KG4, KF4, KF7, KE7, KD7, KR7, KR4, KE4, KB2,   KL4, KO4, KQ4, \
+        KJ2, KJ5, KI5, KH5, KG5, KG2, KF2, KF5, KE5, KD5, KR5, KR2, KE2, KB3,   KK4, KO7, KQ7, \
+        KI2, KJ3, KI3, KH3, KG3, KG6, KF6, KF3, KE3, KD3, KR3, KR6,      KB1,                  \
+        KN2,KC_NO,KJ1, KI1, KH1, KG1, KG0, KF0, KF1, KE1, KD1, KR0,      KN3,        KO6,      \
+        KA4, KP2, KC6,                KK6,                KC0, KM3, KD0, KA1,   KO0, KK0, KL0  \
+    )
 
 #define LAYOUT_tkl_jis( \
-  KG6,      KH4, KI4, KI2, KI6, KP5, KL6, KM2, KM4, KO4, KO5, KO6, KO0,        KN5, KN7, KP7, \
-  KG4, KG5, KH5, KI5, KJ5, KJ4, KK4, KK5, KL5, KM5, KF5, KF4, KL4, KO7, KO2,   KR4, KC4, KE4, \
-  KG2, KG7, KH7, KI7, KJ7, KJ2, KK2, KK7, KL7, KM7, KF7, KF2, KL2,             KQ4, KC5, KE5, \
-  KH2, KG3, KH3, KI3, KJ3, KJ6, KK6, KK3, KL3, KM3, KF3, KF6, KO3, KO1,                       \
-  KB2, KG1, KH1, KI1, KJ1, KJ0, KK0, KK1, KL1, KM1, KF0, KL0,      KB3,             KC6,      \
-  KP4, KD2, KN6, KG0,           KQ6,           KH0, KI0, KN0, KM0, KP1,        KC0, KQ0, KR0  \
-  ) { /*        00-A    01-B    02-C    03-D    04-E    05-F    06-G    07-H    08-I    09-J    10-K    11-L    12-M    13-N    14-O    15-P    16-Q    17-R */ \
-     /* 0 */  { KC_NO,  KC_NO,  KC0,    KC_NO,  KC_NO,  KF0,    KG0,    KH0,    KI0,    KJ0,    KK0,    KL0,    KM0,    KN0,    KO0,    KC_NO,  KQ0,    KR0   }, \
-     /* 1 */  { KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,  KG1,    KH1,    KI1,    KJ1,    KK1,    KL1,    KM1,    KC_NO,  KO1,    KP1,    KC_NO,  KC_NO }, \
-     /* 2 */  { KC_NO,  KB2,    KC_NO,  KD2,    KC_NO,  KF2,    KG2,    KH2,    KI2,    KJ2,    KK2,    KL2,    KM2,    KC_NO,  KO2,    KC_NO,  KC_NO,  KC_NO }, \
-     /* 3 */  { KC_NO,  KB3,    KC_NO,  KC_NO,  KC_NO,  KF3,    KG3,    KH3,    KI3,    KJ3,    KK3,    KL3,    KM3,    KC_NO,  KO3,    KC_NO,  KC_NO,  KC_NO }, \
-     /* 4 */  { KC_NO,  KC_NO,  KC4,    KC_NO,  KE4,    KF4,    KG4,    KH4,    KI4,    KJ4,    KK4,    KL4,    KM4,    KC_NO,  KO4,    KP4,    KQ4,    KR4   }, \
-     /* 5 */  { KC_NO,  KC_NO,  KC5,    KC_NO,  KE5,    KF5,    KG5,    KH5,    KI5,    KJ5,    KK5,    KL5,    KM5,    KN5,    KO5,    KP5,    KC_NO,  KC_NO }, \
-     /* 6 */  { KC_NO,  KC_NO,  KC6,    KC_NO,  KC_NO,  KF6,    KG6,    KC_NO,  KI6,    KJ6,    KK6,    KL6,    KC_NO,  KN6,    KO6,    KC_NO,  KQ6,    KC_NO }, \
-     /* 7 */  { KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,  KF7,    KG7,    KH7,    KI7,    KJ7,    KK7,    KL7,    KK7,    KL7,    KO7,    KP7,    KC_NO,  KC_NO }  \
+    KJ6,      KI4, KH4, KH2, KH6, KA7, KE6, KD2, KD4, KB4, KB7, KB6, KB0,        KC7, KC5, KA5, \
+    KJ4, KJ7, KI7, KH7, KG7, KG4, KF4, KF7, KE7, KD7, KR7, KR4, KE4, KB5, KB2,   KL4, KO4, KQ4, \
+    KJ2, KJ5, KI5, KH5, KG5, KG2, KF2, KF5, KE5, KD5, KR5, KR2, KE2,             KK4, KO7, KQ7, \
+    KI2, KJ3, KI3, KH3, KG3, KG6, KF6, KF3, KE3, KD3, KR3, KR6, KB3, KB1,                       \
+    KN2,      KJ1, KI1, KH1, KG1, KG0, KF0, KF1, KE1, KD1, KR0, KE0, KN3,             KO6,      \
+    KA4, KP2, KC6, KJ0,           KK6,           KI0, KH0, KC0, KD0, KA1,        KO0, KK0, KL0  \
+    ) { /*         00-A  01-B  02-C  03-D  04-E  05-F  06-G  07-H  08-I  09-J  10-K  11-L  12-M  13-N  14-O  15-P  16-Q  17-R */ \
+        /* 0 */  { ___ , KB0 , KC0 , KD0 , KE0 , KF0 , KG0 , KH0 , KI0 , KJ0 , KK0 , KL0 , ___ , ___ , KO0 , ___ , ___ , KR0 }, \
+        /* 1 */  { KA1 , KB1 , ___ , KD1 , KE1 , KF1 , KG1 , KH1 , KI1 , KJ1 , ___ , ___ , ___ , ___ , ___ , ___ , ___ ,     }, \
+        /* 2 */  { ___ , KB2 , ___ , KD2 , KE2 , KF2 , KG2 , KH2 , KI2 , KJ2 , ___ , ___ , ___ , KN2 , ___ , KP2 , ___ , KR2 }, \
+        /* 3 */  { ___ , KB3 , ___ , KD3 , KE3 , KF3 , KG3 , KH3 , KI3 , KJ3 , ___ , ___ , ___ , KN3 , ___ , ___ , ___ , KR3 }, \
+        /* 4 */  { KA4 , KB4 , ___ , KD4 , KE4 , KF4 , KG4 , KH4 , KI4 , KJ4 , KK4 , KL4 , ___ , ___ , KO4 , ___ , KQ4 , KR4 }, \
+        /* 5 */  { KA5 , KB5 , KC5 , KD5 , KE5 , KF5 , KG5 , KH5 , KI5 , KJ5 , ___ , ___ , ___ , ___ , ___ , ___ , ___ , KR5 }, \
+        /* 6 */  { ___ , KB6 , KC6 , ___ , KE6 , KF6 , KG6 , KH6 , ___ , KJ6 , KK6 , ___ , ___ , ___ , KO6 , ___ , ___ , KR6 }, \
+        /* 7 */  { KA7 , KB7 , KC7 , KD7 , KE7 , KF7 , KG7 , KH7 , KI7 , KJ7 , ___ , ___ , ___ , ___ , KO7 , ___ , KQ7 , KR7 }  \
 }
 
 inline void ph_caps_led_on(void)  { DDRC |=  (1<<6); PORTC &= ~(1<<6); }


### PR DESCRIPTION
It occurred to me while staring blankly at the matrix.c files for both the 2013 and 2015 Pegasus Hoofs that the Pegasus Hoof controller was immaterial to the problem, because the Filco-Costar PCB didn't change – the controller itself was the only variable.

We knew the matrix scan was working for both revisions, so the problem isn't there.

Because the keyboard's PCB doesn't change between 2013 and 2015 revisions, keys that share a row or column for a 2013 revision *also* share rows and columns on the 2015 revision. The real solution was to figure out which keys shared rows or columns, and change the identifiers that way.

```c
#define LAYOUT_tkl_jis( \
    KG6,      KH4, KI4, KI2, KI6, KP5, KL6, KM2, KM4, KO4, KO5, KO6, KO0,        KN5, KN7, KP7, \
    KG4, KG5, KH5, KI5, KJ5, KJ4, KK4, KK5, KL5, KM5, KF5, KF4, KL4, KO7, KO2,   KR4, KC4, KE4, \
    KG2, KG7, KH7, KI7, KJ7, KJ2, KK2, KK7, KL7, KM7, KF7, KF2, KL2,             KQ4, KC5, KE5, \
    KH2, KG3, KH3, KI3, KJ3, KJ6, KK6, KK3, KL3, KM3, KF3, KF6, KO3, KO1,                       \
    KB2,      KG1, KH1, KI1, KJ1, KJ0, KK0, KK1, KL1, KM1, KF0, KL0, KB3,             KC6,      \
    KP4, KD2, KN6, KG0,           KQ6,           KH0, KI0, KN0, KM0, KP1,        KC0, KQ0, KR0  \
```

Here's the JIS layout macro from the 2013 Pegasus Hoof. Escape, Backtick, 1, Tab, Q, A, Z, and Muhenkan (left of the Spacebar) all share Column G. (The Pegasus Hoof codebase uses A through R for the columns, and 0 through 7 for the rows.) Because they share a column here, they share a column for the 2015 Pegasus Hoof also.

On the 2015 codebase, Escape is `KJ6`. Because we know all the above keys share a column, all those keys are `KJ_` on the 2015. Now that the column is known, we make the same comparison for the rows. The Muhenkan key in the 2013 codebase is `KG0`, so we need to find a key that is also a `K_0`. F12 is `KO0`, so we now know Muhenkan and F12 share a row.

```c
#define LAYOUT( \
    KJ6,      KI4, KH4, KH2, KH6, KA7, KE6, KD2, KD4, KB4, KB7, KB6, KB0,   KC7, KC5, KA5, \
    KJ4, KJ7, KI7, KH7, KG7, KG4, KF4, KF7, KE7, KD7, KR7, KR4, KE4, KB2,   KL4, KO4, KQ4, \
    KJ2, KJ5, KI5, KH5, KG5, KG2, KF2, KF5, KE5, KD5, KR5, KR2, KE2, KB3,   KK4, KO7, KQ7, \
    KI2, KJ3, KI3, KH3, KG3, KG6, KF6, KF3, KE3, KD3, KR3, KR6,      KB1,                  \
    KN2, KI6, KJ1, KI1, KH1, KG1, KG0, KF0, KF1, KE1, KD1, KR0,      KN3,        KO6,      \
    KA4, KP2, KC6,                KK6,                KC0, KM3, KD0, KA1,   KO0, KK0, KL0  \
```

Here's the LAYOUT macro for the 2015 Pegasus Hoof. F12 is `KB0`. Since we know Muhenkan shares a column with Escape, and a row with F12, Muhenkan's identifier in the 2015 codebase will be Escape's column `J`, and F12's row `0`, which makes Muhenkan `KJ0`.

We make similar comparisons for the rest of the keys that are not known, and it tells us every identifier we need.
